### PR TITLE
changes for vn7.4_imogen_nc jules branch

### DIFF
--- a/user_guide/doc/source/namelists/imogen.nml.rst
+++ b/user_guide/doc/source/namelists/imogen.nml.rst
@@ -6,7 +6,9 @@ This file contains three namelists called :nml:lst:`IMOGEN_ONOFF_SWITCH`, :nml:l
 
 Since IMOGEN calculates the forcing for an entire year at once, an IMOGEN run must have a start time of 00:00:00 on the 1st of January for some year.
 
-IMOGEN uses the netcdf read functions in JULES to load the driving data. The required driving data is specific humidity (kg/kg), precipitaion (kg/m2/s), wind speed (m/s), incoming shortwave radiation (W/m2), incoming longwave radiation (W/m2), air temeprature (K) and diurnal range of air temperature (K). IMOGEN also needs ``grid_area`` read in via :nml:lst:`JULES_LATLON`. 
+IMOGEN uses the netcdf read functions in JULES to load the driving data. The required driving data is specific humidity (kg/kg), precipitation (kg/m2/s), wind speed (m/s), incoming shortwave radiation (W/m2), incoming longwave radiation (W/m2), air temeprature (K) and diurnal range of air temperature (K). IMOGEN also needs ``grid_area`` read in via :nml:lst:`JULES_LATLON`. 
+
+The meteorological driving data used for IMOGEN are at monthly resolution. IMOGEN requires a monthly climatology and then can use either anomalies from that climatology (:nml:mem:`IMOGEN_RUN_LIST::anlg` set to FALSE and :nml:mem:`IMOGEN_RUN_LIST::anom` set to TRUE) or spatial patterns of changes in each meteorological driving variable per degree of global temperature change (:nml:mem:`IMOGEN_RUN_LIST::anlg` set to TRUE and :nml:mem:`IMOGEN_RUN_LIST::anom` set to TRUE). Patterns can be derived at the required spatial resolution using ESMValTool <https://esmvaltool.org/>.
 
 IMOGEN still reads the 1d data from ascii files within the code - this will change in the near future.
 

--- a/user_guide/doc/source/namelists/imogen.nml.rst
+++ b/user_guide/doc/source/namelists/imogen.nml.rst
@@ -6,11 +6,9 @@ This file contains three namelists called :nml:lst:`IMOGEN_ONOFF_SWITCH`, :nml:l
 
 Since IMOGEN calculates the forcing for an entire year at once, an IMOGEN run must have a start time of 00:00:00 on the 1st of January for some year.
 
-IMOGEN is currently restricted to run only on the HadCM3LC grid, i.e. there are 96 x 56 grid cells where each cell has size 3.75 degrees longitude by 2.5 degrees latitude with no Antarctica. This means that:
+IMOGEN uses the netcdf read functions in JULES to load the driving data. It also needs grid-area read in as an ancillary. 
 
-* :nml:mem:`JULES_INPUT_GRID::nx` = 96 and :nml:mem:`JULES_INPUT_GRID::ny` = 56.
-
-IMOGEN also uses its own I/O, so it expects IMOGEN specific files in a different format to JULES - this may change in the future. Examples of IMOGEN input files can be found in the data provided to run the 'rose stem' test suites on supported platforms (e.g. JASMIN).
+IMOGEN still reads the 1d data from ascii files within the code - this will change in the future.
 
 .. seealso::
    References:
@@ -49,7 +47,7 @@ IMOGEN also uses its own I/O, so it expects IMOGEN specific files in a different
    Switch for IMOGEN.
 
    TRUE
-       IMOGEN is used to generate meteorological forcing data.
+       IMOGEN is used to generate meteorological forcing data and drive JULES.
 
    FALSE
        No effect.
@@ -276,14 +274,6 @@ IMOGEN also uses its own I/O, so it expects IMOGEN specific files in a different
    Number of years of emission data in file.
 
 
-.. nml:member:: file_points_order
-
-   :type: character
-   :default: None
-
-   File containing the mapping of IMOGEN global grid points onto IMOGEN land points (different from the JULES land points).
-
-
 .. nml:member:: initialise_from_dump
 
    :type: logical
@@ -380,35 +370,28 @@ IMOGEN also uses its own I/O, so it expects IMOGEN specific files in a different
    Initial ocean temperature (K).
 
 
-.. nml:member:: dir_patt
+.. nml:member:: file_patt
 
    :type: character
    :default: None
 
-   Directory containing the patterns.
-
-   Files in this directory are expected to be in a specific format - see the IMOGEN example.
+   Netcdf file containing the patterns.  It should be monthly data (12 months total) with the dimension 'imogen_drive' representing time. 
 
 
-.. nml:member:: dir_clim
+.. nml:member:: file_clim
 
    :type: character
    :default: None
 
-   Directory containing initialising climatology.
-
-   Files in this directory are expected to be in a specific format - see the IMOGEN example.
+   Netcdf file containing initialising climatology. It should be monthly data (12 months total) with the dimension 'imogen_drive' representing time.
 
 
-.. nml:member:: dir_anom
+.. nml:member:: file_base_anom
 
    :type: character
    :default: None
 
-   Directory containing prescribed anomalies.
-
-   Files in this directory are expected to be in a specific format - see the IMOGEN example.
-
+   Netcdf files containing prescribed anomalies. There should be one for each year and should be in the form 'file_base_anom' followed by 'year' (4 digits) and '.nc'
 
 
 

--- a/user_guide/doc/source/namelists/imogen.nml.rst
+++ b/user_guide/doc/source/namelists/imogen.nml.rst
@@ -6,9 +6,9 @@ This file contains three namelists called :nml:lst:`IMOGEN_ONOFF_SWITCH`, :nml:l
 
 Since IMOGEN calculates the forcing for an entire year at once, an IMOGEN run must have a start time of 00:00:00 on the 1st of January for some year.
 
-IMOGEN uses the netcdf read functions in JULES to load the driving data. It also needs grid-area read in as an ancillary. 
+IMOGEN uses the netcdf read functions in JULES to load the driving data. It also needs ``grid_area`` read in via :nml:lst:`JULES_LATLON`. 
 
-IMOGEN still reads the 1d data from ascii files within the code - this will change in the future.
+IMOGEN still reads the 1d data from ascii files within the code - this will change in the near future.
 
 .. seealso::
    References:

--- a/user_guide/doc/source/namelists/imogen.nml.rst
+++ b/user_guide/doc/source/namelists/imogen.nml.rst
@@ -6,7 +6,7 @@ This file contains three namelists called :nml:lst:`IMOGEN_ONOFF_SWITCH`, :nml:l
 
 Since IMOGEN calculates the forcing for an entire year at once, an IMOGEN run must have a start time of 00:00:00 on the 1st of January for some year.
 
-IMOGEN uses the netcdf read functions in JULES to load the driving data. It also needs ``grid_area`` read in via :nml:lst:`JULES_LATLON`. 
+IMOGEN uses the netcdf read functions in JULES to load the driving data. The required driving data is specific humidity (kg/kg), precipitaion (kg/m2/s), wind speed (m/s), incoming shortwave radiation (W/m2), incoming longwave radiation (W/m2), air temeprature (K) and diurnal range of air temperature (K). IMOGEN also needs ``grid_area`` read in via :nml:lst:`JULES_LATLON`. 
 
 IMOGEN still reads the 1d data from ascii files within the code - this will change in the near future.
 

--- a/user_guide/doc/source/namelists/model_grid.nml.rst
+++ b/user_guide/doc/source/namelists/model_grid.nml.rst
@@ -367,11 +367,12 @@ The following table summarises ancillary fields that give the location and relat
 |                            | This is only required if :nml:mem:`l_coord_latlon` = FALSE.                              |
 |                            | Note that these can have any valid unit.                                                 |
 +----------------------------+------------------------------------------------------------------------------------------+
-| ``grid_area``              | The area of each gridbox (m\ :sup`2`)                                                    |
-|                            | This is only requred if irrigation is being modelled with                                |
+| ``grid_area``              | The area of each gridbox (m\ :sup`2`).                                                   |
+|                            | This is requred if irrigation is being modelled with                                     |
 |                            | :nml:mem:`JULES_WATER_RESOURCES::l_water_resources` = TRUE and                           |
 |                            | :nml:mem:`JULES_WATER_RESOURCES::l_water_irrigation` = TRUE.                             |
-|                            |                                                                                          |
+|                            | It is also required when using IMOGEN:                                                   |
+|                            | :nml:mem:`IMOGEN_ONOFF_SWITCH::l_imogen` = TRUE                                          |
 +----------------------------+------------------------------------------------------------------------------------------+
 
 Examples of how to specify the model domain using through this namelist are provided at the end of this section.
@@ -387,6 +388,9 @@ Land fraction is the fraction of each gridbox that is land. Currently, JULES con
 .. warning::
    When the input grid consists of a single location (1D and :nml:mem:`JULES_INPUT_GRID::npoints` = 1 or 2D and :nml:mem:`JULES_INPUT_GRID::nx` = :nml:mem:`JULES_INPUT_GRID::ny` = 1), that single location is assumed to be 100% land.
    
+   IMOGEN also currently assumes 100% land for each land grid cell.
+
+
 For any input grid with more than a single location, the following are used:
 
 

--- a/user_guide/doc/source/output-variables.rst
+++ b/user_guide/doc/source/output-variables.rst
@@ -1340,7 +1340,8 @@ Grid and indexing variables
 | Name               | Description                                                                            | Dimensions |
 +====================+========================================================================================+============+
 | ``grid_area``      | Gridbox surface area (m\ :sup:`2`).                                                    | land+sea   |
-|                    | Only available if :nml:mem:`JULES_WATER_RESOURCES::l_water_irrigation` = TRUE.         |            |
+|                    | Only available if :nml:mem:`JULES_WATER_RESOURCES::l_water_irrigation` = TRUE.  or     |            |
+|                    | Only available if :nml:mem:`IMOGEN_ONOFF_SWITCH::l_imogen` = TRUE.                     |            |
 +--------------------+----------------------------------------------------------------------------------------+------------+
 | ``grid_area_rp``   | River routing gridbox surface area (m\ :sup:`2`).                                      | np_rivers  |
 |                    | Only available if :nml:mem:`JULES_RIVERS::l_rivers` = TRUE.                            |            |


### PR DESCRIPTION
I have changed the following in imogen namelist docs: dir_anom, dir_patt, dir_clim, file_points_order. These have been changed in vn7.4_imogen_nc, jules ticket #1265. IMOGEN can now be run at any spatial resolution. IMOGEN alos now requires grid_area which is read in through the model_grid namelists. 