### PR TITLE
Deploy documentation updates to gh-pages

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -153,7 +153,12 @@ def commit_changes(args):
 
     run(cmd, check=True)
     logging.info("Committed change %r", message)
-    run(["git", "push"], check=True)
+
+    # Push the update to the upstream repo and branch
+    cmd = ["git", "push", "origin"]
+    if args.gh_pages:
+        cmd.append("gh-pages")
+    run(cmd, check=True)
     logging.info("Pushed automatic commit")
 
     return
@@ -170,6 +175,9 @@ def main():
     parser.add_argument(
         "--no-commit", action="store_true", help="do not commit the changes"
     )
+    parser.add_argument(
+        "--gh-pages", action="store_true", help="deploy to a gh-pages branch"
+    )
     parser.add_argument("release", type=str, help="github release reference")
     args = parser.parse_args()
 
@@ -185,6 +193,16 @@ def main():
     release = JulesDocsRelease(vnumber)
 
     try:
+        if args.gh_pages:
+            # Create a new gh-pages branch and replace the contents
+            # with the current trunk before checking it out
+            cmd = ["git", "branch", "-C", "gh-pages"]
+            run(cmd, check=True)
+            logging.info("Created new gh-pages branch")
+            cmd = ["git", "checkout", "gh-pages"]
+            run(cmd, check=True)
+            logging.info("Checking out gh-pages branch")
+
         release.update_config("user_guide/doc/source/conf.py")
         release.mkdocs()
         release.update_index("index.html")

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -7,8 +7,9 @@
 #
 # Where the event is a push to master on the main repository, the
 # workflow checks for documentation that matches the most recent
-# release tag, install it if necessary, and commits any changes to
-# make the documentation visible via github pages.
+# release tag and adds it to the gh-pages branch as necessary.  The
+# documentation can be published by configuring the repository to
+# use the gh-pages branch.
 
 name: build_docs
 
@@ -66,7 +67,8 @@ jobs:
             # Capture the output status of the command, no matter what
             # it is, without causing the workflow to fail if it is
             # non-zero
-            python3 .github/scripts/release.py --verbose $TAG --gh-pages && STATUS=$? || STATUS=$?
+            python3 .github/scripts/release.py --verbose --gh-pages $TAG \
+                && STATUS=$? || STATUS=$?
 
             # Add a message to the summary
             if [[ $STATUS = 0 ]]; then

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -66,7 +66,7 @@ jobs:
             # Capture the output status of the command, no matter what
             # it is, without causing the workflow to fail if it is
             # non-zero
-            python3 .github/scripts/release.py --verbose $TAG && STATUS=$? || STATUS=$?
+            python3 .github/scripts/release.py --verbose $TAG --gh-pages && STATUS=$? || STATUS=$?
 
             # Add a message to the summary
             if [[ $STATUS = 0 ]]; then


### PR DESCRIPTION
Change the workflow and the release.py script to deploy to a gh-pages branch rather than using the master branch as is presently the case. This should bypass problems associated with the branch controls on main.

In order to take advantage of this change, the github repo settings need to be updated to serve the documentation from the gh-pages branch.