### PR TITLE
Add text to describe correct behaviour of JULES code access form

### DIFF
--- a/access_req/JULES_access.html
+++ b/access_req/JULES_access.html
@@ -54,7 +54,14 @@
                  Any information supplied will be used in accordance with the <a href="http://www.metoffice.gov.uk/about-us/legal/tandc">Met Office privacy policy</a>.
                </p>
                <br/>
-               <p>PLEASE NOTE: It can take up to about 2 weeks for requests to be completed and access give. You will receive an email on completion.
+
+	       <p>Once the form is submitted, the form will open an email with the required information in a string resembling the following:</p>
+
+	       <p>firstname=Firstname&surname=Surname&mail=email%40institution.ac&phone=%2B00+0000+000000&institution=Institution+addess&use=My+JULES+use+will+be...&checkbox=check&submit=Send+Request </p>
+	       <p>Please send the email. If the email fails to open, contact jules-support@metoffice.gov.uk for advice. </p>
+               <br/>
+
+               <p>PLEASE NOTE: It can take up to two weeks for requests to be completed and access given. You will receive an email upon completion. If you have not received confirmation within this time, please check your junk mail/ spam folder before contacting jules-support@metoffice.gov.uk.
                </p>
                </br>
                <form action="mailto:Jules-Support@metoffice.gov.uk?Subject=JULES%20Account%20Request" method="post" entype="multipart/form-data" onsubmit="if(document.getElementById('agree').checked) { return true; } else { alert('Please indicate that you have read and agree to the JULES Terms and Conditions'); return false; }" >

--- a/access_req/JULES_access.html
+++ b/access_req/JULES_access.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>     
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -46,7 +46,7 @@
             <div class="well">
                 <h3>How to request access to the JULES source code</h3>
                 <br/>
-               <p>JULES is freely available to any researcher for non-commercial use, as set out in the <a href="JULES_Licence.pdf">JULES Terms and Conditions</a>. 
+               <p>JULES is freely available to any researcher for non-commercial use, as set out in the <a href="JULES_Licence.pdf">JULES Terms and Conditions</a>.
                 The JULES code is available from the Met Office Science Repository Service, to authenticated users only.
                </p>
                <br/>
@@ -115,4 +115,3 @@
         </div>
     </body>
 </html>
-


### PR DESCRIPTION
jules-support receive many emails reporting that the form didn’t work and then describing what the form is designed to do. This tickets adds a description of the intended behaviour so the applicant knows what to expect to hopefully reduce jules-support admin overheads.
