### PR TITLE
update python/sphinx version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
 
 dependencies:
-  - python>3.7
-  - Sphinx==5.0.2
+  - python=3.11.8
+  - Sphinx==7.3.7
 


### PR DESCRIPTION
Looks like the CI build action is failing as a result of inconsistent python/sphinx dependency.  An initial attempt to bring them both to what's available in Met Office default SciTools stack.