### PR TITLE
Remove web form for JULES access and update statement regarding GitHub

### DIFF
--- a/access_req/JULES_access.html
+++ b/access_req/JULES_access.html
@@ -45,54 +45,9 @@
                 <hr/>
 		<p>
 		  We are pleased to announce the <a href="https://github.com/MetOffice/simulation-systems/wiki/2025.12.1">first release of the Simulation Systems</a> including JULES repository on GitHub. A <a href="https://github.com/">GitHub</a> account will be required for new developments.</p>
-		<p style="color:purple;font-size:16px"> <span>&#9888;&#9888;&#9888;</span> Currently the GitHub JULES repository is private but will be made public in the near future. <span>&#9888;&#9888;&#9888;</span></p>
-		<p style="color:purple;font-size:16px"> To access the code in the interim, please continue to use the following form.</p>
+		<p style="color:purple;font-size:16px"> The JULES GitHub repository will be transitioning from a private to a public repository with the next JULES release in mid-July.</p>
+		<p style="color:purple;font-size:16px"> As we make this transition we are suspending new access requests. New JULES access will be available again from the next release with a GitHub account. </p>
                 <hr/>
-            </div>
-            <div class="well">
-                <h3>How to request access to the JULES source code</h3>
-                <br/>
-               <p>JULES is freely available to any researcher for non-commercial use, as set out in the <a href="JULES_Licence.pdf">JULES Terms and Conditions</a>.
-                The JULES code is available from the Met Office Science Repository Service, to authenticated users only.
-               </p>
-               <br/>
-               <p>To request an account for the JULES code repository, please fill in the form below.
-                 Any information supplied will be used in accordance with the <a href="http://www.metoffice.gov.uk/about-us/legal/tandc">Met Office privacy policy</a>.
-               </p>
-               <br/>
-
-	       <p>Once the form is submitted, the form will open an email with the required information in a string resembling the following:</p>
-
-	       <p>firstname=Firstname&surname=Surname&mail=email%40institution.ac&phone=%2B00+0000+000000&institution=Institution+addess&use=My+JULES+use+will+be...&checkbox=check&submit=Send+Request </p>
-	       <p>Please send the email. If the email fails to open, contact jules-support@metoffice.gov.uk for advice. </p>
-               <br/>
-
-               <p>PLEASE NOTE: It can take up to two weeks for requests to be completed and access given. You will receive an email upon completion. If you have not received confirmation within this time, please check your junk mail/ spam folder before contacting jules-support@metoffice.gov.uk.
-               </p>
-               </br>
-               <form action="mailto:Jules-Support@metoffice.gov.uk?Subject=JULES%20Account%20Request" method="post" entype="multipart/form-data" onsubmit="if(document.getElementById('agree').checked) { return true; } else { alert('Please indicate that you have read and agree to the JULES Terms and Conditions'); return false; }" >
-               <p>
-               <input type="hidden"/><br/>
-               Firstname:<br/>
-               <input type="text" name="firstname" value="Firstname"/><br/>
-               Surname/Family name:<br/>
-               <input type="text" name="surname" value="Surname"/><br/>
-               Email address:</br>
-               Please use your institution email address (i.e. NOT gmail/hotmail/etc.)<br/>
-               <input type="text" name="mail" value="email@institution.ac"/><br/>
-               Telephone number:</br>
-               <input type="text" name="phone" value="+00 0000 000000" /><br/>
-               Institution:</br>
-               Or postal address if not applicable<br/>
-               <textarea name="institution" rows="4" cols="30">Institution addess</textarea><br/>
-               How will you be using JULES?<br/>
-               A brief description of how you intend to use JULES in your research. Please be more specific than "for land-surface modelling".<br/>
-               <textarea name="use" rows="6" cols="50">My JULES use will be...</textarea><br/>
-               <input type="checkbox" name="checkbox" value="check" id="agree" />  I accept the JULES Terms and Conditions:
-               <a href="JULES_Licence.pdf">JULES Terms and Conditions</a>
-               <input type="submit" name="submit" value="Send Request"/><br/>
-               </p>
-               </form>
             </div>
             <div class="container">
             </div>            <hr/>

--- a/access_req/JULES_access.html
+++ b/access_req/JULES_access.html
@@ -47,6 +47,8 @@
 		  We are pleased to announce the <a href="https://github.com/MetOffice/simulation-systems/wiki/2025.12.1">first release of the Simulation Systems</a> including JULES repository on GitHub. A <a href="https://github.com/">GitHub</a> account will be required for new developments.</p>
 		<p style="color:purple;font-size:16px"> The JULES GitHub repository will be transitioning from a private to a public repository with the next JULES release in mid-July.</p>
 		<p style="color:purple;font-size:16px"> As we make this transition we are suspending new access requests. New JULES access will be available again from the next release with a GitHub account. </p>
+		<p style="color:purple;font-size:16px"> Thank you for your interest in JULES and your understanding. </p>
+
                 <hr/>
             </div>
             <div class="container">

--- a/access_req/JULES_access.html
+++ b/access_req/JULES_access.html
@@ -44,11 +44,11 @@
                 <h2>Requesting access to the JULES code</h2>
                 <hr/>
 		<p>
-		  We are pleased to announce the <a href="https://github.com/MetOffice/simulation-systems/wiki/2025.12.1">first release of the Simulation Systems</a> including JULES repository on GitHub. A <a href="https://github.com/">GitHub</a> account will be required for new developments.</p>
-		<p style="color:purple;font-size:16px"> The JULES GitHub repository will be transitioning from a private to a public repository with the next JULES release in mid-July.</p>
-		<p style="color:purple;font-size:16px"> As we make this transition we are suspending new access requests. New JULES access will be available again from the next release with a GitHub account. </p>
-		<p style="color:purple;font-size:16px"> Thank you for your interest in JULES and your understanding. </p>
-
+		  In December 2025 the <a href="https://github.com/MetOffice/simulation-systems/wiki/2025.12.1">first release of the Simulation Systems</a> including <a href="https://github.com/MetOffice/jules">JULES</a> repository on GitHub was announced. A <a href="https://github.com/">GitHub</a> account will be required for new developments.</p>
+		<p style="color:purple;font-size:16px"> The <a href="https://github.com/MetOffice/jules">JULES</a> GitHub repository is currently private (vn8.0 & vn8.1) with access to registered users. It will become a <i>public</i> repository with the next <a href="https://github.com/MetOffice/jules">JULES</a> release in mid-July (vn8.2), allowing anyone to contribute.</p>
+		<p style="color:purple;font-size:16px"> As we make this transition we are suspending new access requests. </p>
+		<p style="color:purple;font-size:16px"> Please note that while a GitHub account is required to <b>contribute</b> to a repository, it is not necessary to access a public one.</p>
+		<p style="color:purple;font-size:16px"> Thank you for your interest in <a href="https://github.com/MetOffice/jules">JULES</a> and your understanding. </p>
                 <hr/>
             </div>
             <div class="container">


### PR DESCRIPTION
As JULES GitHub is transitioning from private to public access at the next JULES release in mid-July. It has been decided to suspend new JULES access requests to the private repository and to MOSRS.